### PR TITLE
Modify the preferences asynchronously

### DIFF
--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -134,7 +134,7 @@ android {
     buildToolsVersion "20.0.0"
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 9
         targetSdkVersion 20
         versionCode 5
         versionName "1.1.1"

--- a/Library/src/main/java/info/metadude/android/typedpreferences/BooleanPreference.java
+++ b/Library/src/main/java/info/metadude/android/typedpreferences/BooleanPreference.java
@@ -47,17 +47,17 @@ public class BooleanPreference {
     }
 
     /**
-     * Stores the given {@code boolean} value.
+     * Stores the given {@code boolean} value asynchronously.
      */
     public void set(boolean value) {
-        mPreferences.edit().putBoolean(mKey, value).commit();
+        mPreferences.edit().putBoolean(mKey, value).apply();
     }
 
     /**
-     * Removes this preference setting.
+     * Removes this preference setting asynchronously.
      */
     public void delete() {
-        mPreferences.edit().remove(mKey).commit();
+        mPreferences.edit().remove(mKey).apply();
     }
 
 }

--- a/Library/src/main/java/info/metadude/android/typedpreferences/DoublePreference.java
+++ b/Library/src/main/java/info/metadude/android/typedpreferences/DoublePreference.java
@@ -43,14 +43,14 @@ public class DoublePreference {
     }
 
     /**
-     * Stores the given {@code double} value.
+     * Stores the given {@code double} value asynchronously.
      */
     public void set(double value) {
         mLongPreference.set(Double.doubleToLongBits(value));
     }
 
     /**
-     * Removes this preference setting.
+     * Removes this preference setting asynchronously.
      */
     public void delete() {
         mLongPreference.delete();

--- a/Library/src/main/java/info/metadude/android/typedpreferences/FloatPreference.java
+++ b/Library/src/main/java/info/metadude/android/typedpreferences/FloatPreference.java
@@ -47,17 +47,17 @@ public class FloatPreference {
     }
 
     /**
-     * Stores the given {@code float} value.
+     * Stores the given {@code float} value asynchronously.
      */
     public void set(float value) {
-        mPreferences.edit().putFloat(mKey, value).commit();
+        mPreferences.edit().putFloat(mKey, value).apply();
     }
 
     /**
-     * Removes this preference setting.
+     * Removes this preference setting asynchronously.
      */
     public void delete() {
-        mPreferences.edit().remove(mKey).commit();
+        mPreferences.edit().remove(mKey).apply();
     }
 
 }

--- a/Library/src/main/java/info/metadude/android/typedpreferences/IntPreference.java
+++ b/Library/src/main/java/info/metadude/android/typedpreferences/IntPreference.java
@@ -47,17 +47,17 @@ public class IntPreference {
     }
 
     /**
-     * Stores the given {@code int} value.
+     * Stores the given {@code int} value asynchronously.
      */
     public void set(final int value) {
-        mPreferences.edit().putInt(mKey, value).commit();
+        mPreferences.edit().putInt(mKey, value).apply();
     }
 
     /**
-     * Removes this preference setting.
+     * Removes this preference setting asynchronously.
      */
     public void delete() {
-        mPreferences.edit().remove(mKey).commit();
+        mPreferences.edit().remove(mKey).apply();
     }
 
 }

--- a/Library/src/main/java/info/metadude/android/typedpreferences/LongPreference.java
+++ b/Library/src/main/java/info/metadude/android/typedpreferences/LongPreference.java
@@ -47,17 +47,17 @@ public class LongPreference {
     }
 
     /**
-     * Stores the given {@code long} value.
+     * Stores the given {@code long} value asynchronously.
      */
     public void set(long value) {
-        mPreferences.edit().putLong(mKey, value).commit();
+        mPreferences.edit().putLong(mKey, value).apply();
     }
 
     /**
-     * Removes this preference setting.
+     * Removes this preference setting asynchronously.
      */
     public void delete() {
-        mPreferences.edit().remove(mKey).commit();
+        mPreferences.edit().remove(mKey).apply();
     }
 
 }

--- a/Library/src/main/java/info/metadude/android/typedpreferences/StringPreference.java
+++ b/Library/src/main/java/info/metadude/android/typedpreferences/StringPreference.java
@@ -47,17 +47,17 @@ public class StringPreference {
     }
 
     /**
-     * Stores the given {@code String} value.
+     * Stores the given {@code String} value asynchronously.
      */
     public void set(final String value) {
-        mPreferences.edit().putString(mKey, value).commit();
+        mPreferences.edit().putString(mKey, value).apply();
     }
 
     /**
-     * Removes this preference setting.
+     * Removes this preference setting asynchronously.
      */
     public void delete() {
-        mPreferences.edit().remove(mKey).commit();
+        mPreferences.edit().remove(mKey).apply();
     }
 
 }

--- a/TypedPreferencesDemo/build.gradle
+++ b/TypedPreferencesDemo/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "20.0.0"
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 9
         targetSdkVersion 20
         versionCode 1
         versionName "1.1.0"


### PR DESCRIPTION
Using `SharedPreferences.Editor#commit()` saves the preferences synchronously. Using `SharedPreferences.Editor#apply()` is asynchronous. The [documentation](http://developer.android.com/reference/android/content/SharedPreferences.Editor.html#apply%28%29) points out that it's safe to replace calls to `#commit()` with calls to `#apply()` if already ignoring the return value.
